### PR TITLE
Add seaborn to requirements.txt

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -7,3 +7,4 @@ econ-ark
 pandas
 pandas-datareader
 statsmodels
+seaborn


### PR DESCRIPTION
The "durables" notebook uses package seaborn, which is currently not in the requirements file and this makes the notebook unable to run in mybinder.

This adds seaborn to requirements.txt.